### PR TITLE
Update more account names

### DIFF
--- a/pages/accounts.html
+++ b/pages/accounts.html
@@ -43,7 +43,7 @@
                                 <li><a href="https://discord.com/users/234960566278553600" target="_blank">Discord</a></li>
                                 <li><a href="https://github.com/MollyMaclachlan" target="_blank">GitHub</a></li>
                                 <li><a href="https://lemmy.world/u/MurdoMaclachlan" traget="_blank">Lemmy</a></li>
-                                <li><a href="https://www.linuxquestions.org/questions/user/murdo-1234055/" target="_blank">LinuxQuestions</a></li>
+                                <li><a href="https://www.linuxquestions.org/questions/user/mollymaclachlan-1234055/" target="_blank">LinuxQuestions</a></li>
                                 <li><a href="https://mastodon.online/@murdomaclachlan" target="_blank">Mastodon</a></li>
                             </ul>
                         </div>
@@ -51,7 +51,7 @@
                             <ul>
                                 <li><a href="https://www.nexusmods.com/users/79190763" target="_blank">NexusMods</a></li>
                                 <li><a href="https://www.royalroad.com/profile/296119" target="_blank">RoyalRoad</a></li>
-                                <li><a href="https://www.scribblehub.com/profile/105962/murdomaclachlan/" target="_blank">Scribble Hub</a></li>
+                                <li><a href="https://www.scribblehub.com/profile/105962/mollymaclachlan/" target="_blank">Scribble Hub</a></li>
                                 <li><a href="https://steamcommunity.com/id/mollymaclachlan" target="_blank">Steam</a></li>
                                 <li><a href="https://mollymaclachlan.tumblr.com/" target="_blank">Tumblr</a></li>
                                 <li><a href="https://vocal.media/authors/molly-maclachlan" target="_blank">Vocal Media</a></li>


### PR DESCRIPTION
Update the account names for LinuxQuestions and ScribbleHub, as the username changes on these sites have now been approved.
