### PR TITLE
Update cookie storage time

### DIFF
--- a/pages/legal.html
+++ b/pages/legal.html
@@ -48,7 +48,7 @@
                         </ul>
                     </div>
                     <div class="block">
-                        If you ignore the cookie banner or press the 'Decline' button, then the Website will not store any cookies. Withholding your consent will result in the cookie banner continuing to appear every time a page on the Website is loaded, and the Website will not be able to remember your choice of theme. If cookies are accepted, they will be stored for 90 days before automatically expiring.
+                        If you ignore the cookie banner or press the 'Decline' button, then the Website will not store any cookies. Withholding your consent will result in the cookie banner continuing to appear every time a page on the Website is loaded, and the Website will not be able to remember your choice of theme. If cookies are accepted, they will be stored for 7 days before automatically expiring.
                     </div>
                     <div class="block">
                         The Website does not store any cookies apart from those listed above, and does not collect any personal data. You can press the button below to immediately delete any cookies the Website has stored.

--- a/scripts/theme.js
+++ b/scripts/theme.js
@@ -29,7 +29,7 @@ const BODY = document.getElementById("body-container");
 const COOKIE_HTML =
     `<div id='cookie-banner' style='display: none;'>
         <div class='block'>
-            This website may store cookies for the purposes of changing the theme, and for disabling this banner. Cookies are stored for 90 days, and no other data is collected. <a href="` + prefix + `legal.html">See more</a>.
+            This website may store cookies for the purposes of changing the theme, and for disabling this banner. Cookies are stored for 7 days, and no other data is collected. <a href="` + prefix + `legal.html">See more</a>.
         </div>
         <div id="cookie-button-container">
             <button id="cookie-accept" class="button cookie-button" type="button" onclick="accept_cookie()">ACCEPT</button>
@@ -121,7 +121,7 @@ function accept_cookie() {
 function create_cookie(name, value) {
     // only create cookies if the user has accepted them
     if (acceptance_cookie != null) {
-        set_cookie(name, value, DAY_SECONDS * 90);
+        set_cookie(name, value, DAY_SECONDS * 7);
     }
 }
 


### PR DESCRIPTION
For security reasons, most browsers limit client-side cookies to a lifetime of 7 days. GitHub pages are static only, so server-side cookies can't be set. This means this website's cookies will only ever last for 7 days, not 90.
