### PR TITLE
Place cookie banner at start of whole page

### DIFF
--- a/scripts/theme.js
+++ b/scripts/theme.js
@@ -25,7 +25,7 @@ try {
     prefix = "";
 }
 
-const BODY = document.getElementById("body-container");
+const HEADER = document.getElementById("container-header");
 const COOKIE_HTML =
     `<div id='cookie-banner' style='display: none;'>
         <div class='block'>
@@ -40,7 +40,7 @@ const DAY_SECONDS = 86400;
 const HTML = document.getElementsByTagName("html")[0];
 const THEME_ICONS = {"dark": "🔆", "light": "🌘"}
 
-BODY.insertAdjacentHTML("afterbegin", COOKIE_HTML);
+HEADER.insertAdjacentHTML("afterbegin", COOKIE_HTML);
 
 var acceptance_cookie;
 var cookie_popup;


### PR DESCRIPTION
Previously, the cookie banner was placed at the start of the body, meaning people using keyboard controls need to tab through the entire header to Accept/Decline. Given cookie-related laws, I think it's best to make this the first thing people interact with, so I have moved it to be placed at the beginning of the header, code-wise.
