### PR TITLE
Update Contact page

### DIFF
--- a/pages/contact.html
+++ b/pages/contact.html
@@ -33,10 +33,7 @@
                         </a>
                     </div>
                     <div class="block">
-                        For anything relating to Reddit, please see my <a href="https://old.reddit.com/user/MollyMaclachlan/comments/rxlatz/about_messaging_me/">'About: messaging me' post</a> on my Reddit account.
-                    </div>
-                    <div class="block">
-                        To report a problem with this website, please open an issue on <a href="https://codeberg.org/MollyMaclachlan/pages">Codeberg</a> or <a href="https://github.com/MollyMaclachlan/website">GitHub</a>. Thank you!
+                        To report a problem with this website, please open an issue on <a href="https://github.com/MollyMaclachlan/website">GitHub</a>. Thank you!
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
This commit removes the references to messaging me on Reddit (where I am no longer active) and opening an issue on Codeberg (where I am also no longer active) from the Contact page. Neither method of Contact will get through to me these days.
