### PR TITLE
Fix broken links on Mod page

### DIFF
--- a/pages/projects/programming/mods.html
+++ b/pages/projects/programming/mods.html
@@ -43,8 +43,8 @@
                         <div id="no-dismemberment-or-finishers">
                             <h1 class="is-size-5">No Dismemberment or Finishers</h1>
                             <ul class="inline-list inline-list-left">
-                                <li><a href="https://www.nexusmods.com/legendofgrimrock2/mods/4232" target="_blank">1.3x patch version</a></li>
-                                <li><a href="https://www.nexusmods.com/legendofgrimrock2/mods/8154" target="_blank">Next-gen patch version</a></li>
+                                <li><a href="https://www.nexusmods.com/witcher3/mods/4232" target="_blank">1.3x patch version</a></li>
+                                <li><a href="https://www.nexusmods.com/witcher3/mods/8154" target="_blank">Next-gen patch version</a></li>
                             </ul>
                             <div class="block has-top-gap-large">
                                 <strong>No Dismemberment or Finishers</strong> is is a simple mod for <i>The Witcher 3: Wild Hunt</i> that does exactly what it says on the tin: it disables mid-combat dismemberment and the slow motion finisher kills at the end of combat. It also has a variant disabling only mid-combat dismemberment, and another disabling only finishers.


### PR DESCRIPTION
These links incorrectly had "legendofgrimrock2" in the URL instead of "witcher3".
